### PR TITLE
added generative titling to chats feat: Implement automatic and manua…

### DIFF
--- a/chat-cli/app/config.py
+++ b/chat-cli/app/config.py
@@ -119,7 +119,8 @@ DEFAULT_CONFIG = {
     "default_style": "default",
     "max_history_items": 100,
     "highlight_code": True,
-    "auto_save": True
+    "auto_save": True,
+    "generate_dynamic_titles": True
 }
 
 def validate_config(config):

--- a/chat-cli/setup.py
+++ b/chat-cli/setup.py
@@ -14,7 +14,7 @@ with open(os.path.join("app", "__init__.py"), "r", encoding="utf-8") as f:
 
 setup(
     name="chat-console",
-    version="0.1.95",
+    version="0.1.96",
     author="Johnathan Greenaway",
     author_email="john@fimbriata.dev",
     description="A command-line interface for chatting with LLMs, storing chats and (future) rag interactions",


### PR DESCRIPTION
…l conversation title generation

- Add `generate_conversation_title` utility function in `app/utils.py` to generate titles based on the first message using the selected model.
- Include retry logic (2 attempts) in `generate_conversation_title` to handle transient API errors.
- Modify `action_send_message` in `app/main.py` to automatically call the title generation function for the first message of a new conversation.
- Add `generate_dynamic_titles` configuration option (default: True) in `app/config.py` to enable/disable automatic title generation.
- Implement a manual title update feature in `app/main.py`:
    - Add `action_update_title` method to show a modal for input.
    - Add `update_conversation_title` helper method to save changes.
    - Add CSS for the title input modal.
    - Add 't' key binding to trigger the manual update.
- Ensure `ChatList` refreshes when a title is manually updated.