### PR TITLE
UI Update Error Fixed: The primary error, Static.update() got an unex…

### DIFF
--- a/chat-cli/app/ui/chat_interface.py
+++ b/chat-cli/app/ui/chat_interface.py
@@ -136,7 +136,7 @@ class MessageDisplay(Static): # Inherit from Static instead of RichLog
                 # Force a complete replacement
                 self.message.content = content
                 formatted_content = self._format_content(content)
-                self.update(formatted_content, refresh=True)
+                self.update(formatted_content)
                 
                 # Force app-level refresh
                 try:
@@ -153,9 +153,10 @@ class MessageDisplay(Static): # Inherit from Static instead of RichLog
             # For all other updates - ALWAYS update
             self.message.content = content
             formatted_content = self._format_content(content)
-            self.update(formatted_content, refresh=True)
+            # Ensure the update call doesn't have refresh=True
+            self.update(formatted_content) 
             
-            # Force refresh
+            # Force refresh using app.refresh() instead of passing to update()
             try:
                 if self.app:
                     self.app.refresh(layout=True)

--- a/chat-cli/app/utils.py
+++ b/chat-cli/app/utils.py
@@ -753,7 +753,9 @@ def resolve_model_id(model_id_or_name: str) -> str:
         "04-turbo": "gpt-4-turbo",
         "035": "gpt-3.5-turbo",
         "35-turbo": "gpt-3.5-turbo",
-        "35": "gpt-3.5-turbo"
+        "35": "gpt-3.5-turbo",
+        "4.1-mini": "gpt-4.1-mini",  # Add support for gpt-4.1-mini
+        "4.1": "gpt-4.1"  # Add support for gpt-4.1
     }
     
     if input_lower in openai_model_aliases:


### PR DESCRIPTION
…pected keyword argument 'refresh', which was preventing streamed responses from appearing, has been fixed in chat-cli/app/ui/chat_interface.py. I removed the invalid refresh=True argument from the update() calls within the MessageDisplay widget.

Model Alias Added: I added an alias for gpt-4.1-mini in chat-cli/app/utils.py to ensure it's explicitly handled, although the logs suggested it was already being correctly identified as an OpenAI model.