### PR TITLE
feat: Add Windows Ollama server support for WSL users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ chat-cli/CLAUDE.md
 **/.claude/settings.local.json
 env/bin/dotenv
 env/*
+chat-cli/debug_chat_issue.py

--- a/chat-cli/app/main.py
+++ b/chat-cli/app/main.py
@@ -17,8 +17,45 @@ def main():
     parser = argparse.ArgumentParser(description="Pure Console Chat CLI")
     parser.add_argument("initial_message", nargs="?", help="Initial message to send")
     parser.add_argument("--console", action="store_true", help="Force console mode (default)")
+    parser.add_argument("--ollama-host", choices=["wsl", "windows", "auto"], 
+                       help="Ollama server to use: wsl (localhost), windows (Windows host), auto (detect)")
     
     args = parser.parse_args()
+    
+    # Set Ollama URL based on argument
+    if args.ollama_host:
+        if args.ollama_host == "wsl":
+            os.environ["OLLAMA_BASE_URL"] = "http://localhost:11434"
+        elif args.ollama_host == "windows":
+            # Get Windows host IP dynamically
+            try:
+                import subprocess
+                result = subprocess.run(["ip", "route", "show", "default"], 
+                                      capture_output=True, text=True)
+                windows_ip = result.stdout.split()[2] if result.returncode == 0 else "172.20.144.1"
+                os.environ["OLLAMA_BASE_URL"] = f"http://{windows_ip}:11434"
+            except:
+                os.environ["OLLAMA_BASE_URL"] = "http://172.20.144.1:11434"
+        elif args.ollama_host == "auto":
+            # Try Windows first, fallback to WSL
+            try:
+                import subprocess
+                result = subprocess.run(["ip", "route", "show", "default"], 
+                                      capture_output=True, text=True)
+                windows_ip = result.stdout.split()[2] if result.returncode == 0 else "172.20.144.1"
+                
+                import requests
+                # Test Windows Ollama
+                try:
+                    requests.get(f"http://{windows_ip}:11434/api/tags", timeout=2)
+                    os.environ["OLLAMA_BASE_URL"] = f"http://{windows_ip}:11434"
+                    print(f"Using Windows Ollama at {windows_ip}:11434")
+                except:
+                    # Fallback to WSL
+                    os.environ["OLLAMA_BASE_URL"] = "http://localhost:11434"
+                    print("Using WSL Ollama at localhost:11434")
+            except:
+                os.environ["OLLAMA_BASE_URL"] = "http://localhost:11434"
     
     # Run the console interface directly
     try:

--- a/chat-cli/chat-windows
+++ b/chat-cli/chat-windows
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Wrapper script to use Windows Ollama
+exec chat --ollama-host windows "$@"


### PR DESCRIPTION
Enable seamless switching between WSL and Windows Ollama instances with new command-line options. This allows WSL users to access models running on their Windows host without manual configuration.

Changes:
- Add --ollama-host flag with options: wsl, windows, auto
- Auto-detect Windows host IP from WSL routing table
- Support automatic fallback from Windows to WSL with 'auto' option
- Add convenient wrapper script 'chat-windows' for quick Windows access
- Update .gitignore to exclude debug scripts

Usage examples:
  chat --ollama-host windows  # Use Windows Ollama
  chat --ollama-host auto     # Try Windows first, fallback to WSL
  ./chat-windows              # Quick Windows access

Note: Windows Ollama must be configured to accept external connections by setting OLLAMA_HOST=0.0.0.0:11434 on the Windows side.

🤖 Generated with [Claude Code](https://claude.ai/code)